### PR TITLE
画面遷移の実装方法〜Chapter9最後まで

### DIFF
--- a/NewsReader/NewsReader.xcodeproj/project.pbxproj
+++ b/NewsReader/NewsReader.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8B3934D424440A8F00199F8B /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B3934D324440A8F00199F8B /* WebKit.framework */; };
+		8B3934D624440ADA00199F8B /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3934D524440ADA00199F8B /* DetailViewController.swift */; };
 		8BC271852440311B00BC8EC8 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC271842440311B00BC8EC8 /* Item.swift */; };
 		8BF2FA72243EE0A600166EA1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF2FA71243EE0A600166EA1 /* AppDelegate.swift */; };
 		8BF2FA74243EE0A600166EA1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF2FA73243EE0A600166EA1 /* SceneDelegate.swift */; };
@@ -17,7 +19,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		8B3934D12443F07300199F8B /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		8B3934D324440A8F00199F8B /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		8B3934D524440ADA00199F8B /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		8BC271842440311B00BC8EC8 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
 		8BF2FA6E243EE0A600166EA1 /* NewsReader.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NewsReader.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BF2FA71243EE0A600166EA1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -34,6 +37,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B3934D424440A8F00199F8B /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -43,7 +47,7 @@
 		8B3934D02443F07300199F8B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8B3934D12443F07300199F8B /* WebKit.framework */,
+				8B3934D324440A8F00199F8B /* WebKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -75,6 +79,7 @@
 				8BF2FA7C243EE0A700166EA1 /* LaunchScreen.storyboard */,
 				8BF2FA7F243EE0A700166EA1 /* Info.plist */,
 				8BF2FA85243EE1A300166EA1 /* ListViewController.swift */,
+				8B3934D524440ADA00199F8B /* DetailViewController.swift */,
 				8BC271842440311B00BC8EC8 /* Item.swift */,
 			);
 			path = NewsReader;
@@ -153,6 +158,7 @@
 			files = (
 				8BC271852440311B00BC8EC8 /* Item.swift in Sources */,
 				8BF2FA72243EE0A600166EA1 /* AppDelegate.swift in Sources */,
+				8B3934D624440ADA00199F8B /* DetailViewController.swift in Sources */,
 				8BF2FA74243EE0A600166EA1 /* SceneDelegate.swift in Sources */,
 				8BF2FA86243EE1A300166EA1 /* ListViewController.swift in Sources */,
 			);

--- a/NewsReader/NewsReader/Base.lproj/Main.storyboard
+++ b/NewsReader/NewsReader/Base.lproj/Main.storyboard
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BNZ-5N-NhG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FHS-VX-Bjn">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--List View Controller-->
+        <!--一覧-->
         <scene sceneID="oHf-Fd-2hx">
             <objects>
                 <tableViewController id="BNZ-5N-NhG" customClass="ListViewController" customModule="NewsReader" customModuleProvider="target" sceneMemberID="viewController">
@@ -31,6 +32,9 @@
                                         </label>
                                     </subviews>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="PbP-5S-xtv" kind="show" id="a9c-aA-OmG"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -38,10 +42,64 @@
                             <outlet property="delegate" destination="BNZ-5N-NhG" id="6Eg-wd-ZKL"/>
                         </connections>
                     </tableView>
+                    <navigationItem key="navigationItem" title="一覧" id="7Tu-Jm-g4J"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gOG-qy-4ej" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="145" y="761"/>
+            <point key="canvasLocation" x="1055.072463768116" y="760.71428571428567"/>
+        </scene>
+        <!--Detail View Controller-->
+        <scene sceneID="VOi-YT-uQt">
+            <objects>
+                <viewController id="PbP-5S-xtv" customClass="DetailViewController" customModule="NewsReader" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="dth-jh-oqN">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XDT-Xk-aI8">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <wkWebViewConfiguration key="configuration">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="XDT-Xk-aI8" firstAttribute="centerX" secondItem="dth-jh-oqN" secondAttribute="centerX" id="2ms-Cr-ABf"/>
+                            <constraint firstItem="XDT-Xk-aI8" firstAttribute="centerY" secondItem="dth-jh-oqN" secondAttribute="centerY" id="NHJ-vw-dKo"/>
+                            <constraint firstItem="XDT-Xk-aI8" firstAttribute="top" secondItem="dth-jh-oqN" secondAttribute="topMargin" constant="-88" id="WZ1-XO-Cnb"/>
+                            <constraint firstItem="XDT-Xk-aI8" firstAttribute="leading" secondItem="jjn-70-c9o" secondAttribute="leading" id="wDA-CX-0kU"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="jjn-70-c9o"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Www-rd-M2b"/>
+                    <connections>
+                        <outlet property="webView" destination="XDT-Xk-aI8" id="Rd6-B4-r2K"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="H1O-br-A62" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1733.3333333333335" y="763.39285714285711"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="5E8-Oi-GD1">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="FHS-VX-Bjn" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="WNc-wq-qbp">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BNZ-5N-NhG" kind="relationship" relationship="rootViewController" id="DOq-Jk-Ujn"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pyb-y8-SJb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="144.92753623188406" y="760.71428571428567"/>
         </scene>
     </scenes>
 </document>

--- a/NewsReader/NewsReader/DetailViewController.swift
+++ b/NewsReader/NewsReader/DetailViewController.swift
@@ -12,6 +12,7 @@ import WebKit
 //UIViewControllerクラスを継承したDetailViewControllerクラスを宣言
 class DetailViewController : UIViewController {
     
+    @IBOutlet weak var webView: WKWebView!
     var link:String!
     
     override func viewDidLoad() {
@@ -25,7 +26,4 @@ class DetailViewController : UIViewController {
             self.webView.load(request)
         }
     }
-    
-    @IBOutlet weak var webView: WKWebView!
-    
 }

--- a/NewsReader/NewsReader/DetailViewController.swift
+++ b/NewsReader/NewsReader/DetailViewController.swift
@@ -1,0 +1,31 @@
+//
+//  DetailViewController.swift
+//  NewsReader
+//
+//  Created by 開発アカウント on 2020/04/13.
+//  Copyright © 2020 開発アカウント. All rights reserved.
+//
+
+import UIKit
+import WebKit
+
+//UIViewControllerクラスを継承したDetailViewControllerクラスを宣言
+class DetailViewController : UIViewController {
+    
+    var link:String!
+    
+    override func viewDidLoad() {
+        //viewDidLoad内に記述しているので、画面が表示される前に呼び出される
+        super.viewDidLoad()
+        //linkプロパティを引数にして、URLクラスのurlインスタンスを作成する
+        if let url = URL(string: self.link) {
+            //urlインスタンスを引数にして、URLRequestクラスのrequestインスタンスを作成する
+            let request = URLRequest(url: url)
+            //requestインスタンスを引数にして、webViewクラスのインスタンスを作成する
+            self.webView.load(request)
+        }
+    }
+    
+    @IBOutlet weak var webView: WKWebView!
+    
+}

--- a/NewsReader/NewsReader/ListViewController.swift
+++ b/NewsReader/NewsReader/ListViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-//XMLPerserクラスのデリゲートになる為のXMLPerserDelegateをほ批准
+//XMLPerserクラスのデリゲートになる為のXMLPerserDelegateを批准
 class ListViewController: UITableViewController, XMLParserDelegate {
     
     //RSSデータ解析の為のXMLPerserクラスのインスタンス格納の為のparserプロパティ
@@ -63,7 +63,6 @@ class ListViewController: UITableViewController, XMLParserDelegate {
                 namespaceURI: String?,
                 qualifiedName qName: String?,
                 attributes attributeDict: [String : String]) {
-        //ニュース記事の要素名からitemを見つける
         //一時的に要素を保存する為の変数currentStringを空にする
         self.currentString = ""
         //RSSデータの要素名を文字列「item」と比較し、要素名がitemのデータのみを取得
@@ -95,6 +94,19 @@ class ListViewController: UITableViewController, XMLParserDelegate {
     func parserDidEndDocument(_ parser: XMLParser) {
         //reloadDataメソッドを実行する事で24,30行目のメソッドが再実行され、データが表示される
         self.tableView.reloadData()
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        //ユーザーがタップしたセルのindexPathを取得
+        if let indexPath = self.tableView.indexPathForSelectedRow {
+            let item = items[indexPath.row]
+            //定数controllerには、遷移先のビューコントローラーが格納されている
+            let controller = segue.destination as! DetailViewController
+            //遷移先の(DetailViewController)のtitleプロパティに記事のタイトルを格納
+            controller.title = item.title
+            //DetailViewControllerのlinkプロパティに記事のURLを格納
+            controller.link = item.link
+        }
     }
 }
 


### PR DESCRIPTION
DetailViewControllerを作成
　・WebKitを使用するためにフレームワークをインポート
　・DetailViewControllerクラスの宣言
　　→ListViewControllerからセグエと共にURLを受け取り、viewDidLoadを使用して画面表示前にload(_:)メソッドを実行。WebKitを使用してページを表示。

Main.storyboard
　・ナビゲーションコントローラーを追加
　・ViewControllerを追加し、記事一覧画面から遷移する設定
　・Selection SegueをShowに設定し、遷移先画面にWebKit Viewを配置
　・WebKit ViewをDetailViewController.swiftと接続